### PR TITLE
Swagger Documentation Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Start the server with the following command:
 nodemon app.mjs
 ```
 
+## API Documentation
+
+For a quick view of the API's structure and endpoints, run the API and visit "/api-docs" endpoint. This will pull up the Swagger UI.

--- a/app.mjs
+++ b/app.mjs
@@ -3,7 +3,7 @@ import express from "express";
 import bodyParser from "body-parser";
 import cors from "cors";
 import swaggerUi from "swagger-ui-express";
-import swaggerDocument from "./swagger.json" assert { type: "json" };
+import swaggerDocument from "./docs/swagger.json" assert { type: "json" };
 
 // Import the routers
 import productsRouter from "./routes/productsRouter.mjs";
@@ -12,7 +12,7 @@ import productsRouter from "./routes/productsRouter.mjs";
 const app = express();
 const port = 3030;
 
-// Swagger UI setup. This provide API documentation at "/api-docs" endpoint. 
+// Swagger UI setup. This provide API documentation at "/api-docs" endpoint.
 app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Use the body parser middleware to parse the body of incoming requests

--- a/app.mjs
+++ b/app.mjs
@@ -2,12 +2,18 @@
 import express from "express";
 import bodyParser from "body-parser";
 import cors from "cors";
+import swaggerUi from "swagger-ui-express";
+import swaggerDocument from "./swagger.json" assert { type: "json" };
+
 // Import the routers
 import productsRouter from "./routes/productsRouter.mjs";
 
 // Create a new Express application
 const app = express();
 const port = 3030;
+
+// Swagger UI setup. This provide API documentation at "/api-docs" endpoint. 
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 // Use the body parser middleware to parse the body of incoming requests
 app.use(express.json());

--- a/controllers/products.mjs
+++ b/controllers/products.mjs
@@ -82,9 +82,7 @@ const deleteProduct = async (req, res) => {
 // Update a product
 const updateProduct = async (req, res) => {
   try {
-    console.log(req.body);
-    const productId = req.body.id;
-    console.log("product ID: " + productId);
+    const productId = req.params.id;
     if (!productId) {
       return res.status(400).json({ error: "Product ID not provided" });
     }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -29,14 +29,14 @@
       "post": {
         "tags": ["Products"],
         "summary": "Create a new product",
-        "description": "Creates a new product.",
+        "description": "Creates a new product without needing an ID in the request body.",
         "parameters": [
           {
             "name": "product",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/Product"
+              "$ref": "#/definitions/NewProduct"
             }
           }
         ],
@@ -71,41 +71,50 @@
             }
           }
         }
-      }
-    },
-    "/user": {
-      "get": {
-        "tags": ["User"],
-        "summary": "Get user information",
-        "description": "Returns information about the user.",
+      },
+      "delete": {
+        "tags": ["Products"],
+        "summary": "Delete a product by id",
+        "description": "Deletes a single product by id.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
         "responses": {
-          "200": {
-            "description": "User information",
-            "schema": {
-              "$ref": "#/definitions/User"
-            }
+          "204": {
+            "description": "Product successfully deleted"
           }
         }
       },
-      "post": {
-        "tags": ["User"],
-        "summary": "Create a new user",
-        "description": "Creates a new user account.",
+      "patch": {
+        "tags": ["Products"],
+        "summary": "Update a product by id",
+        "description": "Updates a single product by id without needing an ID in the request body.",
         "parameters": [
           {
-            "name": "user",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "product",
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/User"
+              "$ref": "#/definitions/NewProduct"
             }
           }
         ],
         "responses": {
-          "201": {
-            "description": "The newly created user account",
+          "200": {
+            "description": "Product successfully updated",
             "schema": {
-              "$ref": "#/definitions/User"
+              "$ref": "#/definitions/Product"
             }
           }
         }
@@ -125,25 +134,67 @@
         "price": {
           "type": "number"
         },
+        "description": {
+          "type": "string"
+        },
+        "imagesUrl": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourcing": {
+          "type": "string"
+        },
         "stock": {
           "type": "integer"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
-    "User": {
+    "NewProduct": {
       "type": "object",
+      "required": [
+        "name",
+        "price",
+        "description",
+        "imagesUrl",
+        "sourcing",
+        "stock",
+        "categories"
+      ],
       "properties": {
-        "id": {
+        "name": {
           "type": "string"
         },
-        "username": {
+        "price": {
+          "type": "number"
+        },
+        "description": {
           "type": "string"
         },
-        "email": {
+        "imagesUrl": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourcing": {
           "type": "string"
         },
-        "password": {
-          "type": "string"
+        "stock": {
+          "type": "integer"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^4.18.2",
         "firebase": "^10.6.0",
         "firebase-admin": "^12.0.0",
-        "nodemon": "^3.0.3"
+        "nodemon": "^3.0.3",
+        "swagger-ui-express": "^5.0.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -3324,6 +3325,25 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.12.0.tgz",
+      "integrity": "sha512-Rt1xUpbHulJVGbiQjq9yy9/r/0Pg6TmpcG+fXTaMePDc8z5WUw4LfaWts5qcNv/8ewPvBIbY7DKq7qReIKNCCQ=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/teeny-request": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.2",
     "firebase": "^10.6.0",
     "firebase-admin": "^12.0.0",
-    "nodemon": "^3.0.3"
+    "nodemon": "^3.0.3",
+    "swagger-ui-express": "^5.0.0"
   }
 }

--- a/routes/productsRouter.mjs
+++ b/routes/productsRouter.mjs
@@ -18,7 +18,7 @@ router.post("/products", createProduct);
 
 router.delete("/products/:id", deleteProduct);
 
-router.patch("/products", updateProduct);
+router.patch("/products/:id", updateProduct);
 
 // Export the router
 export default router;

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,151 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Murphy Ecommerce API",
+    "description": "This API handles all business logic for the ecommerce website.",
+    "version": "1.0.0"
+  },
+  "host": "localhost:3030",
+  "basePath": "/",
+  "schemes": ["http"],
+  "paths": {
+    "/products": {
+      "get": {
+        "tags": ["Products"],
+        "summary": "Get all products",
+        "description": "Returns a list of all products.",
+        "responses": {
+          "200": {
+            "description": "A list of products",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Products"],
+        "summary": "Create a new product",
+        "description": "Creates a new product.",
+        "parameters": [
+          {
+            "name": "product",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The newly created product",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        }
+      }
+    },
+    "/products/{id}": {
+      "get": {
+        "tags": ["Products"],
+        "summary": "Get a product by id",
+        "description": "Returns a single product by id.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A single product",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get user information",
+        "description": "Returns information about the user.",
+        "responses": {
+          "200": {
+            "description": "User information",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["User"],
+        "summary": "Create a new user",
+        "description": "Creates a new user account.",
+        "parameters": [
+          {
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The newly created user account",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "stock": {
+          "type": "integer"
+        }
+      }
+    },
+    "User": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I added Swagger UI to the repository. This will allow anyone to have quick access to the documentation and structure of the API. Useful to establish contracts with the Frontend Team. 

CHANGES:

1. A minor fix to the PATCH endpoint.
> * Before, the PATCH endpoint required the request to have the id of the document inside of the request body. Now, the PATCH endpoint requires the request to have the document id as a parameter ("/products/:id").
> * This makes it more clear what document the PATCH endpoint should be targeting.
> * This makes it harder for the request body to update the id of the document or introduce a secondary id.

2. Swagger UI Added. Visit "localhost:3030/api-docs" when running the API.
> * This provides documentation of all the endpoints in the API and what they require.
> * This also provides quicker testing.
> * The video below shows an example of testing the GET endpoints using Swagger.

https://github.com/4human-org/murphy-ecommerce-backend/assets/58052598/07c80fa0-e03c-4359-b244-4dc69247a5ba


